### PR TITLE
Issue1 アジェンダの削除機能を実装

### DIFF
--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -1,5 +1,5 @@
 class AgendasController < ApplicationController
-  # before_action :set_agenda, only: %i[show edit update destroy]
+  before_action :set_agenda, only: %i[show edit update destroy]
 
   def index
     @agendas = Agenda.all
@@ -15,10 +15,15 @@ class AgendasController < ApplicationController
     @agenda.team = Team.friendly.find(params[:team_id])
     current_user.keep_team_id = @agenda.team.id
     if current_user.save && @agenda.save
-      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda') 
+      redirect_to dashboard_url, notice: I18n.t('views.messages.create_agenda')
     else
       render :new
     end
+  end
+
+  def destroy
+    @agenda.destroy
+    redirect_to dashboard_url
   end
 
   private

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -23,12 +23,7 @@ class AgendasController < ApplicationController
 
   def destroy
     @agenda.destroy
-    # binding.pry
-    @assign_users = Assign.where(team_id: params[:team_id])
-    @users = User.where(id: @assign_users.pluck(:user_id))
-    @users.each do |user|
-      AgendaMailer.agenda_mail(user).deliver
-    end
+    AgendaMailer.agenda_mail(@agenda).deliver
     redirect_to dashboard_url
   end
 

--- a/app/controllers/agendas_controller.rb
+++ b/app/controllers/agendas_controller.rb
@@ -23,6 +23,12 @@ class AgendasController < ApplicationController
 
   def destroy
     @agenda.destroy
+    # binding.pry
+    @assign_users = Assign.where(team_id: params[:team_id])
+    @users = User.where(id: @assign_users.pluck(:user_id))
+    @users.each do |user|
+      AgendaMailer.agenda_mail(user).deliver
+    end
     redirect_to dashboard_url
   end
 

--- a/app/mailers/agenda_mailer.rb
+++ b/app/mailers/agenda_mailer.rb
@@ -1,0 +1,9 @@
+class AgendaMailer < ApplicationMailer
+  default from: 'from@example.com'
+
+  def agenda_mail(user)
+    @user = user
+    mail to: @user.email, subject: 'アジェンダが削除されました'
+  end
+
+end

--- a/app/mailers/agenda_mailer.rb
+++ b/app/mailers/agenda_mailer.rb
@@ -1,9 +1,9 @@
 class AgendaMailer < ApplicationMailer
   default from: 'from@example.com'
 
-  def agenda_mail(user)
-    @user = user
-    mail to: @user.email, subject: 'アジェンダが削除されました'
+  def agenda_mail(agenda)
+    @agenda = agenda
+    mail to: @agenda.team.members.map(&:email), subject: "#{@agenda.title}が削除されました"
   end
 
 end

--- a/app/views/agenda_mailer/agenda_mail.html.erb
+++ b/app/views/agenda_mailer/agenda_mail.html.erb
@@ -1,0 +1,3 @@
+<h1>アジェンダが削除されました</h1>
+
+<a>Agenda title:<%= @agenda.title %></a>

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -33,14 +33,14 @@
             <a href="#" class="nav-link">
               <i class="fa fa-circle-o nav-icon"></i>
               <p>
-                <% if agenda.user_id == current_user.id %>
-                　<%= link_to '×', agenda_path(agenda.id), method: :delete %>
-                <% else %>
-                <% end %>
                 <%= agenda.title %>
                 <i class="right fa fa-angle-left"></i>
               </p>
             </a>
+            <% if agenda.user_id == current_user.id || agenda.team.owner_id == current_user.id %>
+            　<%= link_to t('views.button.delete'), agenda_path(agenda.id), method: :delete, class: "delete_button" %>
+            <% else %>
+            <% end %>
             <ul class="nav nav-treeview" style="display: block;">
               <% agenda.articles.each do |article| %>
                 <li class="nav-item">

--- a/app/views/shared/layout/_sidebar.html.erb
+++ b/app/views/shared/layout/_sidebar.html.erb
@@ -33,6 +33,10 @@
             <a href="#" class="nav-link">
               <i class="fa fa-circle-o nav-icon"></i>
               <p>
+                <% if agenda.user_id == current_user.id %>
+                　<%= link_to '×', agenda_path(agenda.id), method: :delete %>
+                <% else %>
+                <% end %>
                 <%= agenda.title %>
                 <i class="right fa fa-angle-left"></i>
               </p>

--- a/spec/mailers/agenda_spec.rb
+++ b/spec/mailers/agenda_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe AgendaMailer, type: :mailer do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/mailers/previews/agenda_preview.rb
+++ b/spec/mailers/previews/agenda_preview.rb
@@ -1,0 +1,4 @@
+# Preview all emails at http://localhost:3000/rails/mailers/agenda
+class AgendaPreview < ActionMailer::Preview
+
+end


### PR DESCRIPTION
AgendasControllerのdestroyアクションを追加し、そこに機能追加する
Agendaの名前の右の部分に削除ボタンを作成し、そのボタンを押すとそのAgendaが削除される
Agendaに紐づいているarticleも一緒に削除される
Agendaを削除できるのは、そのAgendaの作者もしくはそのAgendaに紐づいているTeamの作者（オーナー）のみ
Agendaが削除されると、そのAgendaに紐づいているTeamに所属しているユーザー全員に通知メールが飛ぶ
情報処理が完了した後はDashBoardに飛ぶ